### PR TITLE
Hide response count from non-admin users

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -87,8 +87,12 @@ export default async function DashboardPage() {
               </CardHeader>
               <CardContent className="flex flex-1 flex-col justify-end gap-3">
                 <p className="text-sm text-muted-foreground">
-                  {form.questions.length} question{form.questions.length !== 1 ? "s" : ""} &middot;{" "}
-                  {form._count.submissions} response{form._count.submissions !== 1 ? "s" : ""}
+                  {form.questions.length} question{form.questions.length !== 1 ? "s" : ""}
+                  {isAdmin && (
+                    <>
+                      {" "}&middot; {form._count.submissions} response{form._count.submissions !== 1 ? "s" : ""}
+                    </>
+                  )}
                 </p>
                 <Link href={`/forms/${form.id}`}>
                   <Button className="w-full">Take Survey</Button>


### PR DESCRIPTION
## Summary
- Hides the survey response count (e.g. "5 responses") from regular users on the dashboard
- Admins still see the full "X questions · Y responses" text
- Regular users now only see "X questions"

Closes #3

## Plan
The dashboard survey cards showed `{count} responses` to all users. The issue requested hiding this from non-admin users since only admins need visibility into response volume. The fix wraps the response count in an `{isAdmin && (...)}` conditional, which was already available in the component.

## Test plan
- [ ] Log in as a regular user and verify survey cards only show question count
- [ ] Log in as an admin and verify survey cards show both question count and response count

🤖 Generated with [Claude Code](https://claude.com/claude-code)