### PR TITLE
Add admin password reset for users

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { DeleteUserButton } from "./delete-user-button";
+import { ResetPasswordButton } from "./reset-password-button";
 
 export default async function AdminUsersPage() {
   const session = await auth();
@@ -62,10 +63,16 @@ export default async function AdminUsersPage() {
                   <p className="text-sm text-muted-foreground">{user.email}</p>
                 </div>
                 {user.id !== session.user.id && (
-                  <DeleteUserButton
-                    userId={user.id}
-                    userName={user.name || user.email}
-                  />
+                  <div className="flex items-center gap-2">
+                    <ResetPasswordButton
+                      userId={user.id}
+                      userName={user.name || user.email}
+                    />
+                    <DeleteUserButton
+                      userId={user.id}
+                      userName={user.name || user.email}
+                    />
+                  </div>
                 )}
               </CardHeader>
               <CardContent>

--- a/src/app/admin/users/reset-password-button.tsx
+++ b/src/app/admin/users/reset-password-button.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function ResetPasswordButton({
+  userId,
+  userName,
+}: {
+  userId: string;
+  userName: string;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters");
+      return;
+    }
+
+    if (
+      !confirm(
+        `Are you sure you want to reset the password for ${userName}?`
+      )
+    )
+      return;
+
+    setLoading(true);
+    const res = await fetch(`/api/admin/users/${userId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password }),
+    });
+
+    if (res.ok) {
+      setPassword("");
+      setOpen(false);
+      router.refresh();
+      alert("Password has been reset successfully.");
+    } else {
+      const data = await res.json();
+      setError(data.error || "Failed to reset password");
+    }
+    setLoading(false);
+  }
+
+  if (!open) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+      >
+        Reset Password
+      </Button>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-center gap-2">
+      <Input
+        type="password"
+        placeholder="New password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="h-8 w-44"
+        autoFocus
+      />
+      <Button type="submit" size="sm" disabled={loading}>
+        {loading ? "Saving..." : "Save"}
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          setOpen(false);
+          setPassword("");
+          setError("");
+        }}
+      >
+        Cancel
+      </Button>
+      {error && <span className="text-xs text-red-600">{error}</span>}
+    </form>
+  );
+}

--- a/src/app/api/admin/users/[userId]/route.ts
+++ b/src/app/api/admin/users/[userId]/route.ts
@@ -1,6 +1,42 @@
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const session = await auth();
+
+  if (!session || session.user?.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { userId } = await params;
+  const { password } = await request.json();
+
+  if (!password || typeof password !== "string" || password.length < 8) {
+    return NextResponse.json(
+      { error: "Password must be at least 8 characters" },
+      { status: 400 }
+    );
+  }
+
+  const user = await db.user.findUnique({ where: { id: userId } });
+
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const hashedPassword = await bcrypt.hash(password, 12);
+  await db.user.update({
+    where: { id: userId },
+    data: { hashedPassword },
+  });
+
+  return NextResponse.json({ success: true });
+}
 
 export async function DELETE(
   _request: Request,


### PR DESCRIPTION
## Summary
- Adds a PATCH endpoint to `/api/admin/users/[userId]` that accepts a new password, hashes it with bcryptjs, and updates the user record
- Adds a "Reset Password" button on the admin user management page that expands into an inline form with password input, Save, and Cancel
- Admin-only access enforced on the API; passwords must be at least 8 characters

Closes #4

## Plan
Since the app has no email functionality, the approach is simple: admins assign a new password directly from the user management page. The flow is:
1. Admin clicks "Reset Password" next to a user
2. An inline form appears with a password input
3. Admin enters the new password and clicks Save (with a confirmation dialog)
4. The API hashes the password and updates the database

## Test plan
- [ ] Log in as admin, go to `/admin/users`
- [ ] Verify "Reset Password" button appears next to non-admin users but not next to yourself
- [ ] Click "Reset Password" — confirm inline form appears with input, Save, and Cancel
- [ ] Try submitting with fewer than 8 characters — should show validation error
- [ ] Submit a valid password — should see success alert
- [ ] Log out and log in as the user whose password was reset, using the new password

🤖 Generated with [Claude Code](https://claude.com/claude-code)